### PR TITLE
fix: InvalidPathException on file save

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.4+build.1
 loader_version=0.15.0
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=me.sootysplash
 archives_base_name=packet-logger
 

--- a/src/client/java/me/sootysplash/MainPL.java
+++ b/src/client/java/me/sootysplash/MainPL.java
@@ -154,13 +154,13 @@ private static double round(double toRound){
     }
 
     public static String getCurrentTimeStamp() {
-        SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");
         Date now = new Date();
         return sdfDate.format(now);
     }
 
     public static String getCurrentHourStamp() {
-        SimpleDateFormat sdfDate = new SimpleDateFormat("HH:mm:ss");
+        SimpleDateFormat sdfDate = new SimpleDateFormat("HH-mm-ss");
         Date now = new Date();
         return sdfDate.format(now);
     }


### PR DESCRIPTION
This pull requests fixes a Minecraft crash caused by an InvalidPathException when disconnecting from the server. Colons used in the date formatting do not allow Windows to save the file properly, so I replaced them with dashes.